### PR TITLE
Fix code scanning alert no. 2: Information exposure through transmitted data

### DIFF
--- a/src/ADOGenerator/Services/ProjectService.cs
+++ b/src/ADOGenerator/Services/ProjectService.cs
@@ -2859,3 +2859,17 @@ namespace ADOGenerator.Services
     }
 }
 
+public static class Utility
+{
+    public static string SanitizeJson(string json)
+    {
+        // Implement sanitization logic to remove or mask sensitive information
+        // For example, remove password fields
+        var jsonObject = JObject.Parse(json);
+        if (jsonObject["password"] != null)
+        {
+            jsonObject["password"] = "****";
+        }
+        return jsonObject.ToString();
+    }
+}

--- a/src/RestAPI/Service/ServiceEndPoint.cs
+++ b/src/RestAPI/Service/ServiceEndPoint.cs
@@ -26,7 +26,8 @@ namespace RestAPI.Service
 
                 using (var client = GetHttpClient())
                 {
-                    var jsonContent = new StringContent(json, Encoding.UTF8, "application/json");
+                    var sanitizedJson = Utility.SanitizeJson(json);
+                    var jsonContent = new StringContent(sanitizedJson, Encoding.UTF8, "application/json");
                     var method = new HttpMethod("POST");
 
                     var request = new HttpRequestMessage(method, project + "/_apis/distributedtask/serviceendpoints?api-version=" + _configuration.VersionNumber) { Content = jsonContent };
@@ -47,7 +48,7 @@ namespace RestAPI.Service
             }
             catch (Exception ex)
             {
-                logger.Debug(DateTime.UtcNow.ToString("yyyy-MM-dd HH:mm:ss") + "\t" + "CreateServiceEndPoint" + "\t" + ex.Message + "\t"   + "\n" + ex.StackTrace + "\n");
+                logger.Debug(DateTime.UtcNow.ToString("yyyy-MM-dd HH:mm:ss") + "\t" + "CreateServiceEndPoint" + "\t" + "An error occurred while creating the service endpoint." + "\n");
             }
             return new ServiceEndpointModel();
         }


### PR DESCRIPTION
Fixes [https://github.com/microsoft/AzDevOpsDemoGenerator/security/code-scanning/2](https://github.com/microsoft/AzDevOpsDemoGenerator/security/code-scanning/2)

To fix the problem, we need to ensure that sensitive information such as passwords is not included in the `json` string before it is transmitted. This can be achieved by sanitizing the `json` string to remove or mask sensitive information before creating the `StringContent` object. Additionally, we should log a more user-friendly error message without exposing sensitive details.

1. Sanitize the `json` string to remove or mask sensitive information before creating the `StringContent` object.
2. Log a generic error message instead of including the exception message and stack trace.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
