### PR TITLE
Update packages and remove obsolete templates

### DIFF
--- a/src/ADOGenerator/ADOGenerator.csproj
+++ b/src/ADOGenerator/ADOGenerator.csproj
@@ -62,12 +62,16 @@
 	  <None Remove="Templates\DL-Octopus\WorkItems\Task.json" />
 	</ItemGroup>
 	<ItemGroup>
-		<PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
-		<PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="8.0.1" />
-		<PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.1" />
+		<PackageReference Include="Microsoft.Extensions.Configuration" Version="9.0.0" />
+		<PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="9.0.0" />
+		<PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="9.0.0" />
 		<PackageReference Include="Microsoft.VisualStudio.Services.Client" Version="19.225.1" />
 		<PackageReference Include="Microsoft.VisualStudio.Services.ExtensionManagement.WebApi" Version="19.225.1" />
 		<PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+		<PackageReference Include="System.Data.SqlClient" Version="4.9.0" />
+		<PackageReference Include="System.Formats.Asn1" Version="9.0.0" />
+		<PackageReference Include="System.Net.Http" Version="4.3.4" />
+		<PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
 	</ItemGroup>
 	<ItemGroup>
 	  <ProjectReference Include="..\API\API.csproj" />


### PR DESCRIPTION
Update packages and remove obsolete templates

Removed Feature.json, Product Backlog Item.json, and Task.json from Templates\DL-Octopus\WorkItems directory in ADOGenerator.csproj. Updated Microsoft.Extensions.Configuration and related packages to version 9.0.0. Added new package references for System.Data.SqlClient (4.9.0), System.Formats.Asn1 (9.0.0), System.Net.Http (4.3.4), and System.Text.RegularExpressions (4.3.1).