### PR TITLE
Fix code scanning alert no. 1: Information exposure through transmitted data

### DIFF
--- a/src/ADOGenerator/Services/ProjectService.cs
+++ b/src/ADOGenerator/Services/ProjectService.cs
@@ -2870,6 +2870,7 @@ public static class Utility
         {
             jsonObject["password"] = "****";
         }
+        // Add more sanitization logic as needed
         return jsonObject.ToString();
     }
 }

--- a/src/API/Service/ServiceEndPoint.cs
+++ b/src/API/Service/ServiceEndPoint.cs
@@ -25,7 +25,8 @@ namespace RestAPI.Service
 
                 using (var client = GetHttpClient())
                 {
-                    var jsonContent = new StringContent(json, Encoding.UTF8, "application/json");
+                    var sanitizedJson = Utility.SanitizeJson(json);
+                    var jsonContent = new StringContent(sanitizedJson, Encoding.UTF8, "application/json");
                     var method = new HttpMethod("POST");
 
                     var request = new HttpRequestMessage(method, project + "/_apis/distributedtask/serviceendpoints?api-version=" + _configuration.VersionNumber) { Content = jsonContent };


### PR DESCRIPTION
Fixes [https://github.com/microsoft/AzDevOpsDemoGenerator/security/code-scanning/1](https://github.com/microsoft/AzDevOpsDemoGenerator/security/code-scanning/1)

To fix the problem, we need to ensure that the `json` string is sanitized before it is used in the `CreateServiceEndPoint` method. This involves removing or masking any sensitive information such as passwords. We can achieve this by calling a sanitization method on the `json` string before it is used to create the `StringContent`.

- Add a sanitization method to the `Utility` class if it doesn't already exist.
- Call this sanitization method on the `json` string before creating the `StringContent` in the `CreateServiceEndPoint` method.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
