### PR TITLE
Improve template handling and user prompts in Program.cs

### DIFF
--- a/src/ADOGenerator/Program.cs
+++ b/src/ADOGenerator/Program.cs
@@ -198,22 +198,24 @@ bool TryGetTemplateDetails(JToken groupwiseTemplates, string selectedTemplateNam
 
         foreach (var template in templates)
         {
-            if (template["Name"]?.ToString().Equals(selectedTemplateName, StringComparison.OrdinalIgnoreCase) != true) continue;
-
-            templateFolder = template["TemplateFolder"]?.ToString();
-            var templateFolderPath = Path.Combine(Directory.GetCurrentDirectory(), "Templates", templateFolder);
-
-            if (!Directory.Exists(templateFolderPath))
+            if (template["Name"]?.ToString().Equals(selectedTemplateName, StringComparison.OrdinalIgnoreCase) != true)
+                continue;
+            else
             {
-                id.ErrorId().AddMessage($"Template '{selectedTemplateName}' is not found.");
-                return false;
+                templateFolder = template["TemplateFolder"]?.ToString();
+                var templateFolderPath = Path.Combine(Directory.GetCurrentDirectory(), "Templates", templateFolder);
+
+                if (!Directory.Exists(templateFolderPath))
+                {
+                    id.ErrorId().AddMessage($"Template '{selectedTemplateName}' is not found.");
+                    return false;
+                }
+                id.AddMessage($"Template '{selectedTemplateName}' is present.");
+                return true;
             }
 
-            id.AddMessage($"Template '{selectedTemplateName}' is present.");
         }
-        return true;
     }
-
     return false;
 }
 
@@ -221,7 +223,7 @@ bool ValidateExtensions(string templateFolderPath, string id)
 {
     Init init = new Init();
 
-    var extensionsFilePath = Path.Combine(templateFolderPath, "Extensions.json");
+    var extensionsFilePath = Path.Combine(Directory.GetCurrentDirectory(),"Templates",templateFolderPath, "Extensions.json");
     if (!File.Exists(extensionsFilePath))
     {
         return false;
@@ -252,15 +254,15 @@ bool ValidateExtensions(string templateFolderPath, string id)
 
     if (extensions.HasValues)
     {
-        id.AddMessage("Do you want to proceed with this extension? (yes/no):");
+        id.AddMessage("Do you want to proceed with this extension? (yes/No): press enter to confirm");
         var userConfirmation = Console.ReadLine();
-        if (!string.IsNullOrWhiteSpace(userConfirmation) && (userConfirmation.Equals("yes", StringComparison.OrdinalIgnoreCase) || userConfirmation.Equals("y", StringComparison.OrdinalIgnoreCase)))
+        if (string.IsNullOrWhiteSpace(userConfirmation) || (userConfirmation.Equals("yes", StringComparison.OrdinalIgnoreCase) || userConfirmation.Equals("y", StringComparison.OrdinalIgnoreCase)))
         {
             Console.ForegroundColor = ConsoleColor.Yellow;
-            id.AddMessage("Agreed for license? (yes/no):");
+            id.AddMessage("Agreed for license? (yes/no): press enter to confirm");
             Console.ResetColor();
             var licenseConfirmation = Console.ReadLine();
-            if (!string.IsNullOrWhiteSpace(licenseConfirmation) && (licenseConfirmation.Equals("yes", StringComparison.OrdinalIgnoreCase) || licenseConfirmation.Equals("y", StringComparison.OrdinalIgnoreCase)))
+            if (string.IsNullOrWhiteSpace(licenseConfirmation) || (licenseConfirmation.Equals("yes", StringComparison.OrdinalIgnoreCase) || licenseConfirmation.Equals("y", StringComparison.OrdinalIgnoreCase)))
             {
                 id.AddMessage("Confirmed Extension installation");
                 return true;


### PR DESCRIPTION
This pull request includes several changes to the `src/ADOGenerator/Program.cs` file to improve code readability and user interaction. The most important changes include restructuring conditional statements, enhancing user prompts, and modifying file path construction.

Code readability improvements:

* [`src/ADOGenerator/Program.cs`](diffhunk://#diff-928ede629f21d91400af9eb92d9134435c65f487349cedd357e6599e5702296bL201-R204): Restructured the conditional statement in the `TryGetTemplateDetails` method to improve readability by using an `else` block.

User interaction enhancements:

* [`src/ADOGenerator/Program.cs`](diffhunk://#diff-928ede629f21d91400af9eb92d9134435c65f487349cedd357e6599e5702296bL255-R265): Updated the user prompt messages in the `ValidateExtensions` method to provide clearer instructions, such as adding "press enter to confirm" to the prompts.

File path construction:

* [`src/ADOGenerator/Program.cs`](diffhunk://#diff-928ede629f21d91400af9eb92d9134435c65f487349cedd357e6599e5702296bL211-R226): Modified the construction of the `extensionsFilePath` in the `ValidateExtensions` method to include the current directory and "Templates" folder for more accurate path resolution.

- Refactored `TryGetTemplateDetails` to include an `else` block for template existence checks, improving logic and readability.
- Updated `extensionsFilePath` construction in `ValidateExtensions` to ensure correct path by including current directory and "Templates" folder.
- Enhanced user prompts in `ValidateExtensions` for clearer instructions and adjusted input handling to treat empty input as confirmation.