### PR TITLE
Fix: Ensure compatibility for work item file paths using Path.GetFile…

### DIFF
--- a/src/ADOGenerator/Services/ProjectService.cs
+++ b/src/ADOGenerator/Services/ProjectService.cs
@@ -1,4 +1,4 @@
-﻿using ADOGenerator.IServices;
+using ADOGenerator.IServices;
 using ADOGenerator.Models;
 using Microsoft.Extensions.Configuration;
 using Microsoft.VisualStudio.Services.Common;
@@ -551,7 +551,6 @@ namespace ADOGenerator.Services
             #region work items
             Dictionary<string, string> workItems = new();
             string _WitPath = GetJsonFilePath(model.IsPrivatePath, model.PrivateTemplatePath, templateUsed, "WorkItems");
-            //Path.Combine(templatesFolder + templateUsed + "\\WorkItems");
             if (Directory.Exists(_WitPath))
             {
                 string[] workItemFilePaths = Directory.GetFiles(_WitPath);
@@ -559,18 +558,14 @@ namespace ADOGenerator.Services
                 {
                     foreach (var workItem in workItemFilePaths)
                     {
-                        string[] workItemPatSplit = workItem.Split('\\');
-                        if (workItemPatSplit.Length > 0)
+                        string workItemName = Path.GetFileName(workItem); // Use Path.GetFileName for cross-platform compatibility
+                        if (!string.IsNullOrEmpty(workItemName))
                         {
-                            string workItemName = workItemPatSplit[workItemPatSplit.Length - 1];
-                            if (!string.IsNullOrEmpty(workItemName))
+                            string[] nameExtension = workItemName.Split('.');
+                            string name = nameExtension[0];
+                            if (!workItems.ContainsKey(name))
                             {
-                                string[] nameExtension = workItemName.Split('.');
-                                string name = nameExtension[0];
-                                if (!workItems.ContainsKey(name))
-                                {
-                                    workItems.Add(name, model.ReadJsonFile(workItem));
-                                }
+                                workItems.Add(name, model.ReadJsonFile(workItem));
                             }
                         }
                     }
@@ -581,7 +576,6 @@ namespace ADOGenerator.Services
             if (File.Exists(projectSettingsFile))
             {
                 string attchmentFilesFolder = GetJsonFilePath(model.IsPrivatePath, model.PrivateTemplatePath, templateUsed, "WorkItemAttachments");
-                //string.Format(templatesFolder + @"{0}\WorkItemAttachments", templateUsed);
                 if (listPullRequestJsonPaths.Count > 0)
                 {
                     if (templateUsed == "MyHealthClinic")
@@ -603,7 +597,6 @@ namespace ADOGenerator.Services
                 }
                 model.id.AddMessage("Work Items created");
             }
-
             #endregion
 
             //Creat TestPlans and TestSuites


### PR DESCRIPTION
This pull request makes improvements to the `CreateProjectEnvironment` method in the `ProjectService` class for better code clarity and cross-platform compatibility. It also includes a minor change to the `using` directives. Below is a summary of the most important changes:

### Code clarity and maintainability:

* Replaced a commented-out line with a functional implementation using `Path.GetFileName` to extract the file name from a path, ensuring cross-platform compatibility. (`src/ADOGenerator/Services/ProjectService.cs`, [src/ADOGenerator/Services/ProjectService.csL554-R561](diffhunk://#diff-381a959bf359ea5015c2ab0d877b21f03078a8a9c40d16fb218a35b6bccb5de2L554-R561))
* Removed unnecessary commented-out code related to file paths to improve readability. (`src/ADOGenerator/Services/ProjectService.cs`, [src/ADOGenerator/Services/ProjectService.csL578-L584](diffhunk://#diff-381a959bf359ea5015c2ab0d877b21f03078a8a9c40d16fb218a35b6bccb5de2L578-L584))

### Minor formatting and cleanup:

* Removed an extra blank line in the method to tidy up the code. (`src/ADOGenerator/Services/ProjectService.cs`, [src/ADOGenerator/Services/ProjectService.csL606](diffhunk://#diff-381a959bf359ea5015c2ab0d877b21f03078a8a9c40d16fb218a35b6bccb5de2L606))
* Adjusted the `using` directives without functional impact. (`src/ADOGenerator/Services/ProjectService.cs`, [src/ADOGenerator/Services/ProjectService.csL1-R1](diffhunk://#diff-381a959bf359ea5015c2ab0d877b21f03078a8a9c40d16fb218a35b6bccb5de2L1-R1))…Name for cross-platform support