### PR TITLE
Add Getting Started section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,10 @@ The Azure DevOps Demo Generator can create projects in your Azure DevOps organiz
 
 The original purpose of this system is to simplify working with the [Azure DevOps hands-on-labs](https://www.azuredevopslabs.com), demos and other education material. But it can also be used to drive your ownAzure DevOps automation utilities, provision your own custom templates, or as a reference for using the [Azure DevOps REST APIs](https://learn.microsoft.com/en-us/rest/api/azure/devops/).
 
+## Getting Started
+
+For step-by-step instructions to clone, build, and run the Azure DevOps Demo Generator, see [docs/RunApplication.md](docs/RunApplication.md).
+
 ## Contributions
 
 This project welcomes contributions and suggestions.  Most contributions require you to agree to a Contributor License Agreement (CLA) declaring that you have the right to, and actually do, grant us the rights to use your contribution. For details, visit https://cla.microsoft.com.


### PR DESCRIPTION
**Summary**
Adds a Getting Started section to the README that directs new users to the existing documentation.

**Changes Made**
- Added Getting Started section between About and Contributions sections
- Links to existing `docs/RunApplication.md` for detailed setup instructions
- Surgical change with no modifications to existing content or formatting

**Why This Change**
- New users need a quick entry point to understand how to get started
- The detailed instructions already exist in `docs/RunApplication.md` but aren't referenced upfront in the README
- Improves discoverability of existing documentation

**Testing**
- Verified link to `docs/RunApplication.md` works correctly
- No formatting or structural changes to existing content

**Type of Change**
- [x] Documentation update
- [x] Enhancement to user experience
- [x] No breaking changes

**Related Issues**
Fixes part of #66 - specifically addresses Problem 1 (missing Getting Started section)