### PR TITLE
Improve docs/RunApplication.md instructions

### DIFF
--- a/docs/RunApplication.md
+++ b/docs/RunApplication.md
@@ -1,3 +1,5 @@
+# Running the AzDevOpsDemoGenerator Application
+
 To run the ADOGenerator project as a console application or executable, follow these steps:
 
 ## Prerequisites
@@ -11,12 +13,12 @@ Ensure you have the following installed on your machine:
 1. **Clone the Repository**
    If you haven't already, clone the repository to your local machine:
    ```sh
-   git clone <repository-url>
-   cd <repository-directory>
+   git clone https://github.com/microsoft/AzDevOpsDemoGenerator.git
+   cd AzDevOpsDemoGenerator
    ```
 
 2. **Open the Solution**
-   Open the ADOGenerator.sln solution file in Visual Studio or your preferred IDE.
+   Open the solution file at `src/ADOGenerator.sln` in Visual Studio or your preferred IDE.
 
 3. **Set ADOGenerator as the Startup Project**
    In Visual Studio:


### PR DESCRIPTION
**Summary**
Improves the documentation in `docs/RunApplication.md` with specific repository details and clearer instructions.

**Changes Made**
- Added explicit repository name to header: "Running the AzDevOpsDemoGenerator Application"
- Fixed clone command with actual GitHub URL instead of placeholders
- Specified exact solution file path (`src/ADOGenerator.sln`) for clarity
- Surgical changes with no formatting modifications to existing content

**Why These Changes**
- **Repository name**: Makes it clear which application is being documented
- **Real clone URL**: Users can copy-paste the actual command instead of replacing placeholders
- **Exact file path**: Eliminates confusion about where to find the solution file

**Testing**
- Verified all paths and URLs are correct
- No structural or formatting changes to existing content
- Instructions remain clear and actionable

**Type of Change**
- [x] Documentation improvement
- [x] User experience enhancement  
- [x] No breaking changes

**Related Issues**
Fixes part of #66 - specifically addresses Problem 3 (docs/RunApplication.md improvements)